### PR TITLE
add travis ci and code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,14 @@ jobs:
       script: make test
       after_success:
         - bash <(curl -s https://codecov.io/bash)
+    - stage: build-images
+      language: generic
+      sudo: required
+      before_script:
+        - curl -L https://github.com/opctl/opctl/releases/download/0.1.24/opctl0.1.24.linux.tgz | sudo tar -xzv -C /usr/local/bin
+      services:
+        - docker
+      script:
+        - opctl run build
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+
+jobs:
+  include:
+    - stage: test
+      language: go
+      go:
+        - 1.12.x
+      env:
+        - OS=linux KUBEBUILDER_VERSION=1.0.8
+      before_script:
+        - curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_${OS}_amd64.tar.gz"
+        - tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_${OS}_amd64.tar.gz
+        - mv kubebuilder_${KUBEBUILDER_VERSION}_${OS}_amd64 kubebuilder && sudo mv kubebuilder /usr/local/
+        - export PATH=$PATH:/usr/local/kubebuilder/bin
+      script: make test
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/zachpuck/aks-engine-automation.svg?branch=master)](https://travis-ci.org/zachpuck/aks-engine-automation)
+[![Coverage](https://codecov.io/gh/zachpuck/aks-engine-automation/branch/master/graph/badge.svg)](https://codecov.io/gh/zachpuck/aks-engine-automation)
+
 # AKS engine automation
 
 A Kubernetes operator used to provision Kubernetes clusters in azure utilizing [aks-engine](https://github.com/Azure/aks-engine)


### PR DESCRIPTION
CI will now run in travis-ci and push coverage results to codecov. 
On successful test the docker images will build and push to docker hub